### PR TITLE
Review and test issue contributions

### DIFF
--- a/examples/models/langchain/README.md
+++ b/examples/models/langchain/README.md
@@ -31,3 +31,58 @@ async def main():
 
     print(history.history)
 ```
+
+## Using with OpenAI-compatible APIs
+
+Some OpenAI-compatible APIs may not support the `json_schema` response format. If you encounter errors like:
+
+```
+Invalid parameter: 'response_format' of type 'json_schema' is not supported with this model
+```
+
+You can disable structured output and rely on manual JSON parsing:
+
+```python
+from langchain_openai import ChatOpenAI
+from browser_use import Agent
+from .chat import ChatLangchain
+
+async def main():
+    # Create a LangChain model pointing to an OpenAI-compatible API
+    langchain_model = ChatOpenAI(
+        model='gpt-4o',
+        api_key='your-api-key',
+        base_url='https://your-api-endpoint.com/v1'
+    )
+
+    # Wrap it with ChatLangchain and disable structured output
+    llm = ChatLangchain(
+        chat=langchain_model,
+        disable_structured_output=True  # This avoids json_schema errors
+    )
+
+    agent = Agent(
+        task="Your task here",
+        llm=llm,
+    )
+
+    history = await agent.run()
+```
+
+## Features
+
+- **Structured Output Support**: By default, ChatLangchain will try to use LangChain's structured output features when available
+- **Automatic Fallback**: If structured output fails, it automatically falls back to manual JSON parsing
+- **Compatibility Mode**: Use `disable_structured_output=True` for APIs that don't support OpenAI's structured output features
+- **Error Handling**: Clear error messages guide you when compatibility issues arise
+
+## Supported Models
+
+ChatLangchain works with any LangChain chat model, including:
+- OpenAI models (ChatOpenAI)
+- Anthropic models (ChatAnthropic)
+- Google models (ChatGoogleGenerativeAI)
+- Groq models (ChatGroq)
+- Ollama models (ChatOllama)
+- DeepSeek models
+- Any other LangChain-compatible chat model

--- a/examples/models/langchain/chat.py
+++ b/examples/models/langchain/chat.py
@@ -26,6 +26,9 @@ class ChatLangchain(BaseChatModel):
 
 	# The LangChain model to wrap
 	chat: 'LangChainBaseChatModel'
+	
+	# Option to disable structured output when using incompatible APIs
+	disable_structured_output: bool = False
 
 	@property
 	def model(self) -> str:
@@ -105,7 +108,7 @@ class ChatLangchain(BaseChatModel):
 
 		Args:
 			messages: List of browser-use chat messages
-			output_format: Optional Pydantic model class for structured output (not supported in basic LangChain integration)
+			output_format: Optional Pydantic model class for structured output
 
 		Returns:
 			Either a string response or an instance of output_format
@@ -139,24 +142,59 @@ class ChatLangchain(BaseChatModel):
 
 			else:
 				# Use LangChain's structured output capability
-				try:
-					structured_chat = self.chat.with_structured_output(output_format)
-					parsed_object = await structured_chat.ainvoke(langchain_messages)
+				structured_output_success = False
+				response = None
+				
+				# First, try to use structured output if not disabled
+				if not self.disable_structured_output:
+					try:
+						# For LangChain OpenAI models, disable json_schema mode if it's causing issues
+						if hasattr(self.chat, 'model_kwargs'):
+							# Temporarily modify model kwargs to use json_mode instead of json_schema
+							original_kwargs = getattr(self.chat, 'model_kwargs', {})
+							self.chat.model_kwargs = {**original_kwargs}
+							
+							# Check if this is a ChatOpenAI model with structured output issues
+							if self.chat.__class__.__name__ == 'ChatOpenAI':
+								# Use method="function_calling" instead of default "json_mode"
+								structured_chat = self.chat.with_structured_output(
+									output_format, 
+									method="function_calling"
+								)
+							else:
+								structured_chat = self.chat.with_structured_output(output_format)
+						else:
+							structured_chat = self.chat.with_structured_output(output_format)
+						
+						parsed_object = await structured_chat.ainvoke(langchain_messages)
+						structured_output_success = True
 
-					# For structured output, usage metadata is typically not available
-					# in the parsed object since it's a Pydantic model, not an AIMessage
-					usage = None
+						# For structured output, usage metadata is typically not available
+						# in the parsed object since it's a Pydantic model, not an AIMessage
+						usage = None
 
-					# Type cast since LangChain's with_structured_output returns the correct type
-					return ChatInvokeCompletion(
-						completion=parsed_object,  # type: ignore
-						usage=usage,
-					)
-				except AttributeError:
-					# Fall back to manual parsing if with_structured_output is not available
+						# Type cast since LangChain's with_structured_output returns the correct type
+						return ChatInvokeCompletion(
+							completion=parsed_object,  # type: ignore
+							usage=usage,
+						)
+					except Exception as e:
+						# If structured output fails, fall back to manual parsing
+						# This handles cases where the API doesn't support json_schema
+						if "json_schema" in str(e) or "response_format" in str(e):
+							# Fall through to manual parsing
+							pass
+						else:
+							# Re-raise other errors
+							raise
+				
+				# Fall back to manual parsing if structured output failed or was disabled
+				if not structured_output_success:
 					response = await self.chat.ainvoke(langchain_messages)  # type: ignore
 
-					if not isinstance(response, 'LangChainAIMessage'):
+					from langchain_core.messages import AIMessage as LangChainAIMessage  # type: ignore
+					
+					if not isinstance(response, LangChainAIMessage):
 						raise ModelProviderError(
 							message=f'Response is not an AIMessage: {type(response)}',
 							model=self.name,
@@ -168,7 +206,15 @@ class ChatLangchain(BaseChatModel):
 						if isinstance(content, str):
 							import json
 
-							parsed_data = json.loads(content)
+							# Try to extract JSON from the content
+							# Handle cases where the model returns markdown code blocks
+							content_str = str(content).strip()
+							if content_str.startswith('```json') and content_str.endswith('```'):
+								content_str = content_str[7:-3].strip()
+							elif content_str.startswith('```') and content_str.endswith('```'):
+								content_str = content_str[3:-3].strip()
+							
+							parsed_data = json.loads(content_str)
 							if isinstance(parsed_data, dict):
 								parsed_object = output_format(**parsed_data)
 							else:
@@ -177,7 +223,7 @@ class ChatLangchain(BaseChatModel):
 							raise ValueError('Content is not a string and structured output not supported')
 					except Exception as e:
 						raise ModelProviderError(
-							message=f'Failed to parse response as {output_format.__name__}: {e}',
+							message=f'Failed to parse response as {output_format.__name__}: {e}. Consider using disable_structured_output=True for APIs that do not support structured output.',
 							model=self.name,
 						) from e
 
@@ -187,9 +233,19 @@ class ChatLangchain(BaseChatModel):
 						usage=usage,
 					)
 
+		except ModelProviderError:
+			# Re-raise our own errors
+			raise
 		except Exception as e:
 			# Convert any LangChain errors to browser-use ModelProviderError
-			raise ModelProviderError(
-				message=f'LangChain model error: {str(e)}',
-				model=self.name,
-			) from e
+			error_msg = str(e)
+			if "json_schema" in error_msg or "response_format" in error_msg:
+				raise ModelProviderError(
+					message=f'LangChain model error: {error_msg}. This API may not support structured output. Consider using ChatLangchain with disable_structured_output=True.',
+					model=self.name,
+				) from e
+			else:
+				raise ModelProviderError(
+					message=f'LangChain model error: {error_msg}',
+					model=self.name,
+				) from e

--- a/examples/models/langchain/openai_compatible_example.py
+++ b/examples/models/langchain/openai_compatible_example.py
@@ -1,0 +1,75 @@
+"""
+Example of using LangChain models with OpenAI-compatible APIs that don't support json_schema.
+
+This example demonstrates how to use the ChatLangchain wrapper with disable_structured_output=True
+to avoid json_schema errors when using APIs like aihubmix.com or other OpenAI proxies.
+
+This solves issue #241: https://github.com/browser-use/browser-use/issues/241
+"""
+import asyncio
+import os
+
+from langchain_openai import ChatOpenAI
+from browser_use import Agent
+from examples.models.langchain.chat import ChatLangchain
+
+
+async def main():
+    """Example using ChatLangchain with OpenAI-compatible APIs."""
+    
+    # Create a LangChain model pointing to an OpenAI-compatible API
+    # Replace with your actual API endpoint and key
+    langchain_model = ChatOpenAI(
+        model='gpt-4o',  # or any model supported by your API
+        api_key=os.environ.get('OPENAI_API_KEY', 'your-api-key'),
+        base_url=os.environ.get('OPENAI_API_BASE', 'https://aihubmix.com/v1')
+    )
+    
+    # Wrap it with ChatLangchain and disable structured output
+    # This is crucial for APIs that don't support json_schema response format
+    llm = ChatLangchain(
+        chat=langchain_model,
+        disable_structured_output=True  # Avoids json_schema errors!
+    )
+    
+    # Create your task
+    task = "Go to google.com and search for 'browser automation with Python'"
+    
+    # Create and run the agent
+    agent = Agent(
+        task=task,
+        llm=llm,
+    )
+    
+    print(f'🚀 Starting task: {task}')
+    print(f'🤖 Using model: {llm.name} via {langchain_model.openai_api_base}')
+    print(f'⚙️  Structured output disabled: {llm.disable_structured_output}')
+    
+    try:
+        # Run the agent
+        history = await agent.run()
+        
+        print(f'\n✅ Task completed successfully!')
+        print(f'📊 Steps taken: {len(history.history)}')
+        
+        # Print the final result if available
+        if history.final_result():
+            print(f'📋 Final result: {history.final_result()}')
+    
+    except Exception as e:
+        print(f'\n❌ Error occurred: {type(e).__name__}: {str(e)}')
+        
+        # Check if it's a json_schema error
+        if "json_schema" in str(e) or "response_format" in str(e):
+            print("\n💡 Tip: Make sure you're using ChatLangchain with disable_structured_output=True")
+            print("   This avoids json_schema errors with OpenAI-compatible APIs.")
+
+
+if __name__ == '__main__':
+    print('🌐 Browser-use with OpenAI-compatible APIs Example')
+    print('=' * 50)
+    print('This example shows how to use LangChain models with APIs')
+    print('that don\'t support OpenAI\'s json_schema response format.')
+    print('=' * 50)
+    
+    asyncio.run(main())


### PR DESCRIPTION
Add compatibility mode to ChatLangchain to prevent `json_schema` errors with OpenAI-compatible APIs.

This PR addresses issue #241 by introducing a `disable_structured_output` parameter and intelligent fallback logic in the `ChatLangchain` wrapper. When `json_schema` or `response_format` errors occur with OpenAI-compatible API proxies that do not support structured output, the system now automatically falls back to manual JSON parsing, ensuring the agent can still function.

---
<a href="https://cursor.com/background-agent?bcId=bc-a84a73ae-94e6-4268-8467-ba6e446efaa1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a84a73ae-94e6-4268-8467-ba6e446efaa1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>